### PR TITLE
ci: temporarily disable add-to-project workflow (placeholder)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,1 +1,9 @@
-﻿name: Add items to Dev Workboardrnon:rn issues:rn types: [opened, reopened, labeled, unlabeled]rn pull_request:rn types: [opened, reopened, synchronize, labeled, unlabeled]rnpermissions:rn issues: writern pull-requests: writernjobs:rn add-to-project:rn runs-on: ubuntu-latestrn steps:rn - uses: actions/add-to-project@v0.6.1rn with:rn project-url: https://github.com/users/lizc-au/projects/2rn github-token: ${{ secrets.PROJECTS_TOKEN }}
+name: Add to Project (temporary placeholder)
+on:
+  workflow_dispatch:
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "Temporarily disabled; will be replaced."


### PR DESCRIPTION
Trying to fix workflow add-to-project problems