### PR TITLE
ci/normalize-add-to-project-yaml-2025-09-09

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,24 +1,24 @@
 name: Add items to Dev Workboard
 on:
- issues:
- types:
- - opened
- - reopened
- - transferred
- - labeled
- pull_request_target:
- types:
- - opened
- - reopened
- - labeled
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+      - labeled
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - labeled
 permissions:
- issues: write
- pull-requests: write
+  issues: write
+  pull-requests: write
 jobs:
- add-to-project:
- runs-on: ubuntu-latest
- steps:
- - uses: actions/add-to-project@v1.0.2
- with:
- project-url: https://github.com/users/lizc-au/projects/2
- github-token: ${{ secrets.PROJECTS_TOKEN }}
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/lizc-au/projects/2
+          github-token: ${{ secrets.PROJECTS_TOKEN }}


### PR DESCRIPTION
normalize my-node-app YAML in GitHub editor (bullet lists + PR-target) - resolving failure: Dependabot PRs don’t expose secrets on pull_request; workflow needed pull_request_target. Also some YAML got flattened (indent → 1 space), causing the types parse error.
Future: With pull_request_target + correct YAML, Dependabot PRs should be fine. If a job needs secrets, avoid pull_request or gate it.