### PR TITLE
chore(vscode): add launch config + save-time ESLint fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,12 +2,16 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "node",
       "request": "launch",
-      "name": "Launch Express Server",
-      "program": "${workspaceFolder}/src/server.js",
-      "cwd": "${workspaceFolder}",
-      "console": "integratedTerminal"
+      "restart": true,
+      "runtimeArgs": [
+        "run",
+        "dev"
+      ],
+      "console": "integratedTerminal",
+      "name": "Dev: nodemon (npm run dev)",
+      "runtimeExecutable": "npm",
+      "type": "node"
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,9 @@
   ],
   "prettier.useEditorConfig": true,
   "prettier.endOfLine": "crlf",
-  "git.confirmSync": false
+  "git.confirmSync": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true,
+    "source.organizeImports": true
+  }
 }


### PR DESCRIPTION
Adds .vscode/launch.json to run npm run dev via F5 and enables ESLint fixAll and organizeImports on save. Test: open in VS Code, press F5 (server starts). Edit a .js file and save; ESLint fixes run and imports organize. Risk: low. After merge: delete branch.