### PR TITLE
chore(vscode): add tasks to run dev/test/lint/format

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,35 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "label": "Dev: npm run dev",
+      "script": "dev",
+      "isBackground": true,
+      "problemMatcher": []
+    },
+    {
+      "type": "npm",
+      "label": "Test: npm test",
+      "script": "test",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "type": "npm",
+      "label": "Lint: npm run lint",
+      "script": "lint",
+      "group": {
+        "kind": "build",
+        "isDefault": false
+      }
+    },
+    {
+      "type": "npm",
+      "label": "Format: npm run format",
+      "script": "format"
+    }
+  ]
+}


### PR DESCRIPTION
Adds .vscode/tasks.json with tasks: Dev (npm run dev), Test (npm test, default), Lint (npm run lint), Format (npm run format). How to test: 1) VS Code: Run Task and execute each. 2) Dev starts; tests pass; lint/format run without prompts. Risk: low. After merge: delete branch.