### PR TITLE
chore(ci): pin Node/npm via engines and packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "supertest": "^7.1.4"
   },
   "engines": {
-    "node": ">=22 <23"
+    "node": ">=22.18.0",
+    "npm": ">=10.9.3"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged",
@@ -54,5 +55,6 @@
     "*.{json,md,yml,yaml}": [
       "prettier --write"
     ]
-  }
+  },
+  "packageManager": "npm@10.9.3"
 }


### PR DESCRIPTION
Pins Node >=22.18.0 and npm >=10.9.3; sets packageManager to npm@10.9.3 so local and CI match. After merge: delete branch.