### PR TITLE
chore(vscode): align ESLint save actions to 'explicit'

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,8 +16,8 @@
   "prettier.endOfLine": "crlf",
   "git.confirmSync": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.organizeImports": true
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "explicit"
   },
   "git.autofetch": true,
   "problems.autoReveal": false,


### PR DESCRIPTION
Switch VS Code save actions to 'explicit' for ESLint and organizeImports to match current extension behavior. Prevents unintended on-save edits; no runtime code changes. Test plan: ensure Node CI passes; merge via squash.