### PR TITLE
docs(cheatsheet): add PR workflow (CLI quick steps)

### DIFF
--- a/docs/github-cheatsheet.md
+++ b/docs/github-cheatsheet.md
@@ -1,1 +1,3 @@
 GitHub Pull Requests & Checks
+
+## PR workflow (CLI quick steps)rnrn1. git switch -c feature/short-descrn2. git add -Arn3. git commit -m "feat: short desc"rn4. git push -u origin HEADrn5. gh pr create --fill --base mainrn6. gh pr checks --watchrn7. gh pr merge --squash --delete-branch


### PR DESCRIPTION
Adds a concise PR workflow section to docs/github-cheatsheet.md (branch→commit→push→create PR→checks→merge).