### PR TITLE
docs(cheatsheet): normalize CRLF newlines

### DIFF
--- a/docs/github-cheatsheet.md
+++ b/docs/github-cheatsheet.md
@@ -1,3 +1,11 @@
-GitHub Pull Requests & Checks
+# GitHub Pull Requests & Checks
 
-## PR workflow (CLI quick steps)rnrn1. git switch -c feature/short-descrn2. git add -Arn3. git commit -m "feat: short desc"rn4. git push -u origin HEADrn5. gh pr create --fill --base mainrn6. gh pr checks --watchrn7. gh pr merge --squash --delete-branch
+## PR workflow (CLI quick steps)
+
+1. git switch -c feature/short-desc
+2. git add -A
+3. git commit -m "feat: short desc"
+4. git push -u origin HEAD
+5. gh pr create --fill --base main
+6. gh pr checks --watch
+7. gh pr merge --squash --delete-branch


### PR DESCRIPTION
Normalize CRLF line endings in docs/github-cheatsheet.md to prevent rn artifacts on Windows; no content changes.