### PR TITLE
docs(cheatsheet): add 'Sync local main to origin/main (safe reset)'

### DIFF
--- a/docs/github-cheatsheet.md
+++ b/docs/github-cheatsheet.md
@@ -9,3 +9,5 @@
 5. gh pr create --fill --base main
 6. gh pr checks --watch
 7. gh pr merge --squash --delete-branch
+
+## Sync local main to origin/main (safe reset)rnrnNote: discards local commits on main; move any work to a branch first.rnrn1. git switch mainrn2. git fetch origin --prunern3. git reset --hard origin/main


### PR DESCRIPTION
Adds a safe reset recipe to sync local main to origin/main. Note: move work to a branch first since this discards local commits on main.