### PR TITLE
docs(cheatsheet): add 'Move accidental main commit to PR branch'

### DIFF
--- a/docs/github-cheatsheet.md
+++ b/docs/github-cheatsheet.md
@@ -15,3 +15,5 @@
 ## Watch PR checks (gh)rnrn1. gh pr checks --watchrn2. gh pr checks <number> --watch
 
 ## Merge PR (squash + delete, non-interactive)rnrn1. echo y | gh pr merge <number> --squash --delete-branch
+
+## Move accidental main commit to PR branchrnrnNote: if push to main is blocked by rules, move your local commit to a branch and open a PR.rnrn1. git switch -c fix/short-descrn2. git push -u origin HEADrn3. gh pr create --fill --base main


### PR DESCRIPTION
Adds a quick recipe to move an accidental commit on main to a PR branch when push is blocked by rules (branch → push → create PR).