### PR TITLE
docs(cheatsheet): add 'Add reviewers/assignees/labels to PR (gh)'

### DIFF
--- a/docs/github-cheatsheet.md
+++ b/docs/github-cheatsheet.md
@@ -21,3 +21,5 @@
 ## Update PR branch with latest main (merge)rnrn1. git fetch origin --prunern2. git switch <branch>rn3. git merge origin/mainrn4. npm testrn5. git push
 
 ## Update PR branch with latest main (rebase)rnrn1. git fetch origin --prunern2. git switch <branch>rn3. git rebase origin/mainrn4. Resolve conflicts → git add <file> ; git rebase --continuern5. git push --force-with-lease
+
+## Add reviewers/assignees/labels to PR (gh)rnrn1. gh pr edit <number> --add-reviewer <user1>,<user2>rn2. gh pr edit <number> --add-assignee <user1>,<user2>rn3. gh pr edit <number> --add-label "label-one","label two"


### PR DESCRIPTION
Adds quick commands to manage PR metadata via gh: reviewers, assignees, and labels.